### PR TITLE
Celestial body endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,14 @@ def get_all():
     except Exception as e:
         return(str(e))
 
+@app.route('/api/v1/celestial_bodies/<id>', methods = ['GET'])
+def get_one_body(id):
+    try:
+        celestial_body = CelestialBodies.query.get(id)
+        return jsonify(celestial_body.serialize())
+    except Exception as e:
+        return(str(e))
+
 @app.route('/api/v1/news', methods = ['GET'])
 def get_api():
     try: 

--- a/models.py
+++ b/models.py
@@ -1,5 +1,7 @@
 from app import db
 from sqlalchemy.dialects.postgresql import JSON
+import solarsystem
+import datetime
 
 
 voyages = db.Table('voyages',
@@ -41,9 +43,30 @@ class CelestialBodies(db.Model):
         'celestial_body_type': self.celestial_body_type,
         'gravity': self.gravity,
         'planet_day': self.planet_day,
-        'planet_year': self.planet_year
+        'planet_year': self.planet_year,
+        'travel': self.travel_time()
       }
 
+    def travel_time(self):
+      if self.name == 'Moon':
+        return {'distance': 'test', 'travel_time': 'test'}
+      now    = datetime.datetime.utcnow()
+      now    = datetime.datetime.now(datetime.timezone.utc)
+      year   = now.year
+      month  = now.month
+      day    = now.day
+      hour   = now.hour
+      minute = now.minute
+
+      miles_per_au = 92955807 # Number of miles in one astronomical unit
+      ship_speed = 24816 #Ship speed equal to maximum speed for manned spaceflight
+
+      planets = solarsystem.Geocentric(year=year, month=month, day=day, hour=hour, minute=minute ).position()
+      distance_au = planets[self.name][2]
+      distance_miles = distance_au * miles_per_au
+      travel_time = distance_miles / ship_speed
+
+      return {'distance': distance_miles, 'travel_time': travel_time}
 
 class Landmark(db.Model):
     __tablename__ = 'landmarks'

--- a/models.py
+++ b/models.py
@@ -48,8 +48,12 @@ class CelestialBodies(db.Model):
       }
 
     def travel_time(self):
+      miles_per_au = 92955807 # Number of miles in one astronomical unit
+      ship_speed = 24816 #Ship speed equal to maximum speed for manned spaceflight
+
       if self.name == 'Moon':
-        return {'distance': 'test', 'travel_time': 'test'}
+        moon_distance = 238900
+        return {'distance': moon_distance, 'travel_time': moon_distance / ship_speed}
       now    = datetime.datetime.utcnow()
       now    = datetime.datetime.now(datetime.timezone.utc)
       year   = now.year
@@ -58,14 +62,10 @@ class CelestialBodies(db.Model):
       hour   = now.hour
       minute = now.minute
 
-      miles_per_au = 92955807 # Number of miles in one astronomical unit
-      ship_speed = 24816 #Ship speed equal to maximum speed for manned spaceflight
-
       planets = solarsystem.Geocentric(year=year, month=month, day=day, hour=hour, minute=minute ).position()
       distance_au = planets[self.name][2]
       distance_miles = distance_au * miles_per_au
       travel_time = distance_miles / ship_speed
-
       return {'distance': distance_miles, 'travel_time': travel_time}
 
 class Landmark(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ python-dateutil==2.8.1
 python-editor==1.0.4
 requests==2.24.0
 six==1.15.0
+solarsystem==0.1.5
 SQLAlchemy==1.3.19
 toml==0.10.1
 urllib3==1.25.10


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Migration 
- [ ] Styling
- [ ] Testing

### Commit Emojis:
:bento: Adding new assets or images


### Detailed Description: 
Adds a celestial_bodies/<id> endpoint to give the information about a single celestial body. A new method was added to the celestial body model to get the travel time and distance from the earth on the date and time in which a request is sent. Distances returned are in miles, travel time is returned in hours. This should close issue #12 

### Why is this change required? What problem does it solve?
This change adds a necessary endpoint for the frontend to get the necessary information for a given celestial body.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed? It was difficult to find an API to give us distance data so a library is used to calculate distances on a given date based on mathematical simulations of planetary movement. Another issue is that this library did not include the moon in its calculations so I had to hardcode in the average distance of the moon from earth. Given that the moon orbits earth and has a relatively low variance in its distance from earth I thought this would be fine, whereas average distances for other planets vary greatly from the actual distance depending on the orbits.

### Files modified:
- [ app.py ] 
- [ requirements.txt ] 
- [ models.py ] 
- [ ] 
